### PR TITLE
RFC: Remove <If>

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,45 +120,6 @@ function BulletedReorderable({ list }) {
 ```
 
 
-## If conditions
-
-Use the `test` prop with `<If>` and `<ElseIf>` elements to conditionally
-include certain elements. When an `<If>` test is _truthy_ it does not
-render any `<ElseIf>` or `<Else>` children. However when it is _falsey_ it
-_only_ renders `<ElseIf>` and `<Else>` children.
-
-```js
-<If test={someCondition}>
-  This will only be shown if someCondition is truthy.
-  <ElseIf test={otherCondition}>
-    This will only be shown if someCondition is falsey
-    and otherCondition is truthy.
-    <Else>
-      This will only be shown if both someCondition and
-      otherCondition are both falsey.
-    </Else>
-  </ElseIf>
-  <Else>
-    This will be shown if someCondition is falsey.
-    <If test={finalCondition}>
-      This will be shown if someCondition is falsey
-      and finalCondition is truthy.
-    </If>
-  </Else>
-</If>
-```
-
-Alternatively, you can provide `then` and `else` props.
-
-```js
-<If
-  test={someCondition}
-  then={"This will only be shown if someCondition is truthy."}
-  else={"This will be shown if someCondition is falsey."}
-/>
-```
-
-
 ## What is _React Velcro_?
 
 Only the newest, coolest, most blazing fast React architecture out there!

--- a/react-loops.d.ts
+++ b/react-loops.d.ts
@@ -33,15 +33,3 @@ export function For<O extends Object, K extends keyof O>(
         children: ForCallback<O[K], K>;
       }
 ): React.ReactNode;
-
-export function If(props: {
-  test: any;
-  children: React.ReactNode;
-}): React.ReactNode;
-
-export function ElseIf(props: {
-  test: any;
-  children: React.ReactNode;
-}): React.ReactNode;
-
-export function Else(props: { children: React.ReactNode }): React.ReactNode;

--- a/react-loops.js
+++ b/react-loops.js
@@ -34,7 +34,7 @@ var iterall = require("iterall");
  *
  *   <ul>
  *     <For of={myList} as={(item, { isLast }) =>
- *       <li><If test={isLast}>and </If>{item}</li>
+ *       <li>{isLast && "and "}{item}</li>
  *     }/>
  *   </ul>
  *
@@ -148,76 +148,8 @@ function mapIteration(mapper, item, index, length, key) {
   return result;
 }
 
-/**
- * Use the `test` prop with `<If>` and `<ElseIf>` elements to conditionally
- * include certain elements. When an `<If>` test is _truthy_ it does not
- * render any `<ElseIf>` or `<Else>` children. However when it is _falsey_ it
- * _only_ renders `<ElseIf>` and `<Else>` children.
- *
- *   <If test={someCondition}>
- *     This will only be shown if someCondition is truthy.
- *     <ElseIf test={otherCondition}>
- *       This will only be shown if someCondition is falsey
- *       and otherCondition is truthy.
- *       <Else>
- *         This will only be shown if both someCondition and
- *         otherCondition are both falsey.
- *       </Else>
- *     </ElseIf>
- *     <Else>
- *       This will be shown if someCondition is falsey.
- *       <If test={finalCondition}>
- *         This will be shown if someCondition is falsey
- *         and finalCondition is truthy.
- *       </If>
- *     </Else>
- *   </If>
- *
- * Alternatively, you can provide `then` and `else` props.
- *
- *  <If
- *   test={someCondition}
- *   then={"This will only be shown if someCondition is truthy."}
- *   else={"This will be shown if someCondition is falsey."}
- * />
- *
- */
-function If(props) {
-  var hasTest = props.hasOwnProperty("test");
-  if (!hasTest && !props.hasOwnProperty("case")) {
-    throw new TypeError("<If> requires a `test` prop.");
-  }
-  var condition = Boolean(hasTest ? props.test : props.case);
-  var hasElse = props.hasOwnProperty("else");
-  var hasThen = props.hasOwnProperty("then");
-  if (hasElse && !hasThen) {
-    throw new TypeError("<If> only use `else` prop alongside `then` prop.");
-  }
-  if ((hasThen ^ props.hasOwnProperty("children")) === 0) {
-    throw new TypeError("<If> expects either a `then` prop or children.");
-  }
-  if (hasThen) {
-    return condition ? props.then : hasElse ? props.else : null;
-  }
-  return React.Children.map(props.children, function(child) {
-    var isElse = child.type === Else || child.type === ElseIf;
-    return condition !== isElse ? child : null;
-  });
-}
-
-function Else(props) {
-  return props.children;
-}
-
-function ElseIf(props) {
-  return React.createElement(If, props);
-}
-
 // Export loops
 Object.defineProperties(exports, {
   For: { enumerable: true, value: For },
-  If: { enumerable: true, value: If },
-  Else: { enumerable: true, value: Else },
-  ElseIf: { enumerable: true, value: ElseIf },
   __esModule: { value: true }
 });

--- a/react-loops.js.flow
+++ b/react-loops.js.flow
@@ -33,7 +33,3 @@ declare function For<O: Object>(
       children: ForCallback<$Values<O>, $Keys<O>>
     |}
 ): React$Node;
-
-declare function If({ test: any, children: React$Node }): React$Node;
-declare function ElseIf({ test: any, children: React$Node }): React$Node;
-declare function Else({ children: React$Node }): React$Node;

--- a/react-loops.test.js
+++ b/react-loops.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import { For, If, ElseIf, Else } from "./react-loops.js";
+import { For } from "./react-loops.js";
 
 function expectRenderToEqual(actual, expected) {
   const consoleError = console.error;
@@ -27,368 +27,252 @@ function expectRenderToThrow(actual, error) {
 }
 
 describe("react-loops", () => {
-  describe("for", () => {
-    describe("for-of", () => {
-      it("loops an Array", () => {
-        const list = ["A", "B", "C"];
-        expectRenderToEqual(
-          <For of={list} as={item => <li>{item}</li>} />,
-          <>
-            <li>A</li>
-            <li>B</li>
-            <li>C</li>
-          </>
-        );
-      });
-
-      it("Can use render-prop", () => {
-        const list = ["A", "B", "C"];
-        expectRenderToEqual(
-          <For of={list}>{item => <li>{item}</li>}</For>,
-          <>
-            <li>A</li>
-            <li>B</li>
-            <li>C</li>
-          </>
-        );
-      });
-
-      it("loops an Array-like", () => {
-        const list = { length: 3, 0: "A", 1: "B", 2: "C" };
-        expectRenderToEqual(
-          <For of={list} as={item => <li>{item}</li>} />,
-          <>
-            <li>A</li>
-            <li>B</li>
-            <li>C</li>
-          </>
-        );
-      });
-
-      it("loops TypedArray", () => {
-        const list = new Uint8Array(3);
-        list[1] = 10;
-        list[2] = 20;
-        expectRenderToEqual(
-          <For of={list} as={item => <li>{item}</li>} />,
-          <>
-            <li>{0}</li>
-            <li>{10}</li>
-            <li>{20}</li>
-          </>
-        );
-      });
-
-      it("loops an Iterable", () => {
-        const list = new Set(["A", "B", "C"]);
-        expectRenderToEqual(
-          <For of={list} as={item => <li>{item}</li>} />,
-          <>
-            <li>A</li>
-            <li>B</li>
-            <li>C</li>
-          </>
-        );
-      });
-
-      it("loops null", () => {
-        expectRenderToEqual(
-          <For of={null} as={item => <li>{item}</li>} />,
-          null
-        );
-      });
-
-      it("loops with a non-element string return", () => {
-        const list = ["A", "B", "C"];
-        expectRenderToEqual(
-          <For of={list} as={item => item} />,
-          <>
-            {"A"}
-            {"B"}
-            {"C"}
-          </>
-        );
-      });
-
-      it("loops with a non-element Array return", () => {
-        const list = ["A", "B", "C"];
-        expectRenderToEqual(
-          <For
-            of={list}
-            as={item => [<li key="0">{item}</li>, <li key="1">{item}</li>]}
-          />,
-          <>
-            <li key="woof">A</li>
-            <li>A</li>
-            <li>B</li>
-            <li>B</li>
-            <li>C</li>
-            <li>C</li>
-          </>
-        );
-      });
-
-      it("loops an Array with metadata", () => {
-        const list = ["A", "B", "C"];
-        expectRenderToEqual(
-          <For
-            of={list}
-            as={(item, { index, length, key, isFirst, isLast }) => (
-              <li>
-                {item}
-                {index}
-                {length}
-                {key}
-                {isFirst}
-                {isLast}
-              </li>
-            )}
-          />,
-          <>
-            <li>
-              {"A"}
-              {0}
-              {3}
-              {0}
-              {true}
-              {false}
-            </li>
-            <li>
-              {"B"}
-              {1}
-              {3}
-              {1}
-              {false}
-              {false}
-            </li>
-            <li>
-              {"C"}
-              {2}
-              {3}
-              {2}
-              {false}
-              {true}
-            </li>
-          </>
-        );
-      });
-    });
-
-    describe("for-in", () => {
-      it("loops an Object", () => {
-        const obj = { x: "A", y: "B", z: "C" };
-        expectRenderToEqual(
-          <For in={obj} as={item => <li>{item}</li>} />,
-          <>
-            <li>A</li>
-            <li>B</li>
-            <li>C</li>
-          </>
-        );
-      });
-
-      it("loops null", () => {
-        expectRenderToEqual(
-          <For in={null} as={item => <li>{item}</li>} />,
-          null
-        );
-      });
-
-      it("loops an Object with metadata", () => {
-        const obj = { x: "A", y: "B", z: "C" };
-        expectRenderToEqual(
-          <For
-            in={obj}
-            as={(item, { index, length, key, isFirst, isLast }) => (
-              <li>
-                {item}
-                {index}
-                {length}
-                {key}
-                {isFirst}
-                {isLast}
-              </li>
-            )}
-          />,
-          <>
-            <li>
-              {"A"}
-              {0}
-              {3}
-              {"x"}
-              {true}
-              {false}
-            </li>
-            <li>
-              {"B"}
-              {1}
-              {3}
-              {"y"}
-              {false}
-              {false}
-            </li>
-            <li>
-              {"C"}
-              {2}
-              {3}
-              {"z"}
-              {false}
-              {true}
-            </li>
-          </>
-        );
-      });
-    });
-
-    describe("error cases", () => {
-      it("requires either of or in", () => {
-        expectRenderToThrow(
-          <For as={() => null} />,
-          "<For> expects either an Iterable `of` or Object `in` prop."
-        );
-      });
-
-      it("requires only one of of or in", () => {
-        expectRenderToThrow(
-          <For of={null} in={null} as={() => null} />,
-          "<For> expects either an Iterable `of` or Object `in` prop."
-        );
-      });
-
-      it("requires either as or render-prop", () => {
-        expectRenderToThrow(
-          <For of={null} />,
-          "<For> expects either a render-prop child or a Function `as` prop."
-        );
-      });
-
-      it("requires only one of as or render-prop", () => {
-        expectRenderToThrow(
-          <For of={null} as={() => null}>
-            {() => null}
-          </For>,
-          "<For> expects either a render-prop child or a Function `as` prop."
-        );
-      });
-
-      it("requires either as or render-prop as function", () => {
-        expectRenderToThrow(
-          <For of={null} as={"not a func"} />,
-          "<For> expects either a render-prop child or a Function `as` prop."
-        );
-        expectRenderToThrow(
-          <For of={null}>not a func</For>,
-          "<For> expects either a render-prop child or a Function `as` prop."
-        );
-      });
-    });
-  });
-
-  describe("if", () => {
-    it("includes children if condition is truthy", () => {
-      expectRenderToEqual(<If test={"truthy"}>Truthy?</If>, "Truthy?");
-    });
-
-    it("excludes children if condition is falsey", () => {
-      expectRenderToEqual(<If test={0}>Truthy?</If>, null);
-    });
-
-    it("includes Else child if condition is falsey", () => {
+  describe("for-of", () => {
+    it("loops an Array", () => {
+      const list = ["A", "B", "C"];
       expectRenderToEqual(
-        <If test={0}>
-          Truthy?
-          <Else>Falsey?</Else>
-        </If>,
-        "Falsey?"
-      );
-    });
-
-    it("excludes Else child if condition is truthy", () => {
-      expectRenderToEqual(
-        <If test={1}>
-          Truthy?
-          <Else>Falsey?</Else>
-        </If>,
-        "Truthy?"
-      );
-    });
-
-    it("evaluates ElseIf child if condition is falsey", () => {
-      expectRenderToEqual(
-        <If test={0}>
-          Truthy?
-          <ElseIf test={1}>Otherwise?</ElseIf>
-        </If>,
-        "Otherwise?"
-      );
-    });
-
-    it("does not evaluate If child if condition is falsey", () => {
-      expectRenderToEqual(
-        <If test={0}>
-          Truthy?
-          <If test={1}>Otherwise?</If>
-        </If>,
-        null
-      );
-    });
-
-    it("allows multiple nested ElseIf and Else cases", () => {
-      expectRenderToEqual(
-        <If test={0}>
-          Truthy?
-          <ElseIf test={0}>
-            Otherwise?
-            <Else>Not Otherwise?</Else>
-          </ElseIf>
-          <Else>Falsey?</Else>
-        </If>,
+        <For of={list} as={item => <li>{item}</li>} />,
         <>
-          {"Not Otherwise?"}
-          {"Falsey?"}
+          <li>A</li>
+          <li>B</li>
+          <li>C</li>
         </>
       );
     });
 
-    it("supports then prop", () => {
-      expectRenderToEqual(<If test={1} then={"Truthy?"} />, "Truthy?");
-      expectRenderToEqual(<If test={0} then={"Truthy?"} />, null);
-    });
-
-    it("supports then else prop", () => {
+    it("Can use render-prop", () => {
+      const list = ["A", "B", "C"];
       expectRenderToEqual(
-        <If test={1} then={"Truthy?"} else={"Falsey?"} />,
-        "Truthy?"
-      );
-      expectRenderToEqual(
-        <If test={0} then={"Truthy?"} else={"Falsey?"} />,
-        "Falsey?"
+        <For of={list}>{item => <li>{item}</li>}</For>,
+        <>
+          <li>A</li>
+          <li>B</li>
+          <li>C</li>
+        </>
       );
     });
 
-    it("supports legacy case prop", () => {
-      expectRenderToEqual(<If case={1} then={"Truthy?"} />, "Truthy?");
-      expectRenderToEqual(<If case={0} then={"Truthy?"} />, null);
+    it("loops an Array-like", () => {
+      const list = { length: 3, 0: "A", 1: "B", 2: "C" };
+      expectRenderToEqual(
+        <For of={list} as={item => <li>{item}</li>} />,
+        <>
+          <li>A</li>
+          <li>B</li>
+          <li>C</li>
+        </>
+      );
     });
 
-    describe("error cases", () => {
-      it("requires case", () => {
-        expectRenderToThrow(<If then={null} />, "<If> requires a `test` prop.");
-      });
+    it("loops TypedArray", () => {
+      const list = new Uint8Array(3);
+      list[1] = 10;
+      list[2] = 20;
+      expectRenderToEqual(
+        <For of={list} as={item => <li>{item}</li>} />,
+        <>
+          <li>{0}</li>
+          <li>{10}</li>
+          <li>{20}</li>
+        </>
+      );
+    });
 
-      it("requires either then or children", () => {
-        expectRenderToThrow(
-          <If test={1} />,
-          "<If> expects either a `then` prop or children."
-        );
-      });
+    it("loops an Iterable", () => {
+      const list = new Set(["A", "B", "C"]);
+      expectRenderToEqual(
+        <For of={list} as={item => <li>{item}</li>} />,
+        <>
+          <li>A</li>
+          <li>B</li>
+          <li>C</li>
+        </>
+      );
+    });
 
-      it("requires then when using else", () => {
-        expectRenderToThrow(
-          <If test={1} else={null} />,
-          "<If> only use `else` prop alongside `then` prop."
-        );
-      });
+    it("loops null", () => {
+      expectRenderToEqual(<For of={null} as={item => <li>{item}</li>} />, null);
+    });
+
+    it("loops with a non-element string return", () => {
+      const list = ["A", "B", "C"];
+      expectRenderToEqual(
+        <For of={list} as={item => item} />,
+        <>
+          {"A"}
+          {"B"}
+          {"C"}
+        </>
+      );
+    });
+
+    it("loops with a non-element Array return", () => {
+      const list = ["A", "B", "C"];
+      expectRenderToEqual(
+        <For
+          of={list}
+          as={item => [<li key="0">{item}</li>, <li key="1">{item}</li>]}
+        />,
+        <>
+          <li key="woof">A</li>
+          <li>A</li>
+          <li>B</li>
+          <li>B</li>
+          <li>C</li>
+          <li>C</li>
+        </>
+      );
+    });
+
+    it("loops an Array with metadata", () => {
+      const list = ["A", "B", "C"];
+      expectRenderToEqual(
+        <For
+          of={list}
+          as={(item, { index, length, key, isFirst, isLast }) => (
+            <li>
+              {item}
+              {index}
+              {length}
+              {key}
+              {isFirst}
+              {isLast}
+            </li>
+          )}
+        />,
+        <>
+          <li>
+            {"A"}
+            {0}
+            {3}
+            {0}
+            {true}
+            {false}
+          </li>
+          <li>
+            {"B"}
+            {1}
+            {3}
+            {1}
+            {false}
+            {false}
+          </li>
+          <li>
+            {"C"}
+            {2}
+            {3}
+            {2}
+            {false}
+            {true}
+          </li>
+        </>
+      );
+    });
+  });
+
+  describe("for-in", () => {
+    it("loops an Object", () => {
+      const obj = { x: "A", y: "B", z: "C" };
+      expectRenderToEqual(
+        <For in={obj} as={item => <li>{item}</li>} />,
+        <>
+          <li>A</li>
+          <li>B</li>
+          <li>C</li>
+        </>
+      );
+    });
+
+    it("loops null", () => {
+      expectRenderToEqual(<For in={null} as={item => <li>{item}</li>} />, null);
+    });
+
+    it("loops an Object with metadata", () => {
+      const obj = { x: "A", y: "B", z: "C" };
+      expectRenderToEqual(
+        <For
+          in={obj}
+          as={(item, { index, length, key, isFirst, isLast }) => (
+            <li>
+              {item}
+              {index}
+              {length}
+              {key}
+              {isFirst}
+              {isLast}
+            </li>
+          )}
+        />,
+        <>
+          <li>
+            {"A"}
+            {0}
+            {3}
+            {"x"}
+            {true}
+            {false}
+          </li>
+          <li>
+            {"B"}
+            {1}
+            {3}
+            {"y"}
+            {false}
+            {false}
+          </li>
+          <li>
+            {"C"}
+            {2}
+            {3}
+            {"z"}
+            {false}
+            {true}
+          </li>
+        </>
+      );
+    });
+  });
+
+  describe("error cases", () => {
+    it("requires either of or in", () => {
+      expectRenderToThrow(
+        <For as={() => null} />,
+        "<For> expects either an Iterable `of` or Object `in` prop."
+      );
+    });
+
+    it("requires only one of of or in", () => {
+      expectRenderToThrow(
+        <For of={null} in={null} as={() => null} />,
+        "<For> expects either an Iterable `of` or Object `in` prop."
+      );
+    });
+
+    it("requires either as or render-prop", () => {
+      expectRenderToThrow(
+        <For of={null} />,
+        "<For> expects either a render-prop child or a Function `as` prop."
+      );
+    });
+
+    it("requires only one of as or render-prop", () => {
+      expectRenderToThrow(
+        <For of={null} as={() => null}>
+          {() => null}
+        </For>,
+        "<For> expects either a render-prop child or a Function `as` prop."
+      );
+    });
+
+    it("requires either as or render-prop as function", () => {
+      expectRenderToThrow(
+        <For of={null} as={"not a func"} />,
+        "<For> expects either a render-prop child or a Function `as` prop."
+      );
+      expectRenderToThrow(
+        <For of={null}>not a func</For>,
+        "<For> expects either a render-prop child or a Function `as` prop."
+      );
     });
   });
 });


### PR DESCRIPTION
I think `<If>` and `<Else>` might be a distraction from the value of `<For>` and I'm considering remove it. They're also potentially helpful for clearer syntax compared to `{condition && <Node />}` but have some real drawbacks as well.

Perhaps we should consider including them in a `react-conditionals` library?