### PR TITLE
Fix generic constraint for O

### DIFF
--- a/react-loops.d.ts
+++ b/react-loops.d.ts
@@ -22,7 +22,7 @@ export function For<T>(
         children: ForCallback<T, number>;
       }
 ): React.ReactNode;
-export function For<O extends Object, K extends keyof O>(
+export function For<O extends object, K extends keyof O>(
   props:
     | {
         in: O | null | undefined;


### PR DESCRIPTION
TypeScript's object type is lowercase; the pascal-case version refers specifically to instances of the Object constructor.

It's almost the same until you have some field whose type conflicts with a field from Object.prototype.