### PR TITLE
ifEmpty: Support loop empty condition rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,31 @@ function BulletedDefinitions({ terms }) {
 }
 ```
 
+## Loop empty conditions
+
+A common pattern when rendering a collection is to render a special case when
+the collection is empty. Optionally provide an `ifEmpty` prop to handle this
+case for both `<For in>` and `<For of>` loops.
+
+The `ifEmpty` prop accepts anything renderable (strings, numbers, JSX) or a
+*function* which returns anything renderable.
+
+```js
+import { For } from 'react-loops'
+
+function BulletedWithFallback({ list }) {
+  return (
+     <ul>
+      <For of={list} ifEmpty={<em>Nothing here!</em>}>
+        {item =>
+          <li>{item}</li>
+        }
+      </For>
+    </ul>
+  )
+}
+```
+
 ## Loop iteration metadata
 
 Access additional information about each iteration by destructuring the

--- a/react-loops.d.ts
+++ b/react-loops.d.ts
@@ -1,5 +1,6 @@
 type JSXNode = JSX.Element | string | number | false | null | undefined;
-type JSXChild = JSXNode | Array<JSXNode>
+type JSXChild = JSXNode | Array<JSXNode>;
+type LazyJSXChild = (() => JSXChild) | JSXChild;
 
 type ForCallback<T, K> = (
   item: T,
@@ -16,10 +17,12 @@ export function For<T>(
   props:
     | {
         of: Iterable<T> | ArrayLike<T> | null | undefined;
+        ifEmpty?: LazyJSXChild;
         as: ForCallback<T, number>;
       }
     | {
         of: Iterable<T> | ArrayLike<T> | null | undefined;
+        ifEmpty?: LazyJSXChild;
         children: ForCallback<T, number>;
       }
 ): JSX.Element;
@@ -27,10 +30,12 @@ export function For<O extends {}, K extends keyof O>(
   props:
     | {
         in: O | null | undefined;
+        ifEmpty?: LazyJSXChild;
         as: ForCallback<O[K], K>;
       }
     | {
         in: O | null | undefined;
+        ifEmpty?: LazyJSXChild;
         children: ForCallback<O[K], K>;
       }
 ): JSX.Element;

--- a/react-loops.js.flow
+++ b/react-loops.js.flow
@@ -16,20 +16,24 @@ type ArrayLike<T> = { +length: number, +[number]: T };
 declare function For<T>(
   | {|
       of: Iterable<T> | ArrayLike<T> | null | void,
+      ifEmpty?: (() => React$Node) | React$Node,
       as: ForCallback<T, number>
     |}
   | {|
       of: Iterable<T> | ArrayLike<T> | null | void,
+      ifEmpty?: (() => React$Node) | React$Node,
       children: ForCallback<T, number>
     |}
 ): React$Node;
 declare function For<O: Object>(
   | {|
       in: O | null | void,
+      ifEmpty?: (() => React$Node) | React$Node,
       as: ForCallback<$Values<O>, $Keys<O>>
     |}
   | {|
       in: O | null | void,
+      ifEmpty?: (() => React$Node) | React$Node,
       children: ForCallback<$Values<O>, $Keys<O>>
     |}
 ): React$Node;

--- a/react-loops.test.js
+++ b/react-loops.test.js
@@ -168,39 +168,96 @@ describe("react-loops", () => {
         </>
       );
     });
-  });
 
-  it("loops an IterableIterator with metadata", () => {
-    const list = new Map([["x", "A"], ["y", "B"], ["z", "C"]]);
-    expectRenderToEqual(
-      <For
-        of={list.keys()}
-        as={(key, { index, length }) => (
+    it("loops an IterableIterator with metadata", () => {
+      const list = new Map([["x", "A"], ["y", "B"], ["z", "C"]]);
+      expectRenderToEqual(
+        <For
+          of={list.keys()}
+          as={(key, { index, length }) => (
+            <li>
+              {key}
+              {index}
+              {length}
+            </li>
+          )}
+        />,
+        <>
           <li>
-            {key}
-            {index}
-            {length}
+            {"x"}
+            {0}
+            {3}
           </li>
-        )}
-      />,
-      <>
-        <li>
-          {"x"}
-          {0}
-          {3}
-        </li>
-        <li>
-          {"y"}
-          {1}
-          {3}
-        </li>
-        <li>
-          {"z"}
-          {2}
-          {3}
-        </li>
-      </>
-    );
+          <li>
+            {"y"}
+            {1}
+            {3}
+          </li>
+          <li>
+            {"z"}
+            {2}
+            {3}
+          </li>
+        </>
+      );
+    });
+
+    describe("ifEmpty", () => {
+      it("is used with an empty Array", () => {
+        const list = [];
+        expectRenderToEqual(
+          <For
+            of={list}
+            as={item => <li>{item}</li>}
+            ifEmpty={<b>Nothing here</b>}
+          />,
+          <>
+            <b>Nothing here</b>
+          </>
+        );
+      });
+
+      it("allows a lazy function", () => {
+        const list = [];
+        expectRenderToEqual(
+          <For
+            of={list}
+            as={item => <li>{item}</li>}
+            ifEmpty={() => <b>Nothing here</b>}
+          />,
+          <>
+            <b>Nothing here</b>
+          </>
+        );
+      });
+
+      it("is used with null", () => {
+        expectRenderToEqual(
+          <For
+            of={null}
+            as={item => <li>{item}</li>}
+            ifEmpty={<b>Nothing here</b>}
+          />,
+          <>
+            <b>Nothing here</b>
+          </>
+        );
+      });
+
+      it("is used with an empty iterable", () => {
+        const set = new Set();
+        expectRenderToEqual(
+          <For
+            of={set}
+            as={item => <li>{item}</li>}
+            ifEmpty={<b>Nothing here</b>}
+          />,
+          <>
+            <b>Nothing here</b>
+          </>
+        );
+      });
+    });
   });
 
   describe("for-in", () => {
@@ -292,6 +349,49 @@ describe("react-loops", () => {
           </li>
         </>
       );
+    });
+
+    describe("ifEmpty", () => {
+      it("is used with an empty Object", () => {
+        const obj = {};
+        expectRenderToEqual(
+          <For
+            in={obj}
+            as={item => <li>{item}</li>}
+            ifEmpty={<b>Nothing here</b>}
+          />,
+          <>
+            <b>Nothing here</b>
+          </>
+        );
+      });
+
+      it("allows a lazy function", () => {
+        const obj = {};
+        expectRenderToEqual(
+          <For
+            in={obj}
+            as={item => <li>{item}</li>}
+            ifEmpty={() => <b>Nothing here</b>}
+          />,
+          <>
+            <b>Nothing here</b>
+          </>
+        );
+      });
+
+      it("is used with null", () => {
+        expectRenderToEqual(
+          <For
+            in={null}
+            as={item => <li>{item}</li>}
+            ifEmpty={<b>Nothing here</b>}
+          />,
+          <>
+            <b>Nothing here</b>
+          </>
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Adds `ifEmpty` as a prop for For-in and For-of loops to support a fallback rendering when a collection or object is empty or null.

Closes #16